### PR TITLE
:rocket: Travis: account for upstream change in the unit tests setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,9 @@ script:
     # Lint the PHP files against parse errors.
     - if [[ "$LINT" == "1" ]]; then if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
     # Run the unit tests.
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then phpunit --filter GoogleWebDev $PHPCS_DIR/tests/AllTests.php; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." ]]; then php $PHPUNIT_DIR/phpunit-5.7.21.phar  --filter GoogleWebDev $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." && ${PHPCS_BRANCH:0:3} == "3.0" ]]; then phpunit --filter GoogleWebDev $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:2} != "5." && ${PHPCS_BRANCH:0:3} == "3.0" ]]; then php $PHPUNIT_DIR/phpunit-5.7.21.phar  --filter GoogleWebDev $PHPCS_DIR/tests/AllTests.php; fi
+    - if [[ ${PHPCS_BRANCH:0:3} != "3.0" ]]; then phpunit --bootstrap=$PHPCS_DIR/tests/bootstrap.php --filter GoogleWebDev $PHPCS_DIR/tests/AllTests.php; fi
     # Check the code style of the code base.
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_BIN . --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the xml file.


### PR DESCRIPTION
PHPCS didn't support PHPUnit 6.x up to now.
Upstream PR squizlabs/PHP_CodeSniffer#1384 has now been merged adding this, but does require a bootstrap file to be loaded for the unit tests to work.

Once PHPCS 3.1.0 has been released, I suggest dropping support for lower PHPCS versions. That will allow us to simplify the unit test line to just the last line of the current set of three.